### PR TITLE
DVX-6819 Make vm.max_map_count persist after reboot

### DIFF
--- a/.ebextensions/00_setup_elasticsearch.config
+++ b/.ebextensions/00_setup_elasticsearch.config
@@ -109,7 +109,8 @@ files:
 
         echo $CURRENT_MD5 > ~/.esconfigversion
 
-        sysctl -w vm.max_map_count=262144
+        echo vm.max_map_count = 262144 >> /etc/sysctl.conf
+        sysctl -p
 
         echo "Done!"
       else


### PR DESCRIPTION
This parameter, when wrong set, prevents ES from start. The change on how
to set it up ensures this is persisted on instance reboot.

Refs [DVX-6819](https://mydevex.atlassian.net/browse/DVX_6819)