### PR TITLE
DVX-8195 Improve ES cluster setup configuration

### DIFF
--- a/.ebextensions/00_cloud.config
+++ b/.ebextensions/00_cloud.config
@@ -1,0 +1,35 @@
+option_settings:
+  aws:autoscaling:launchconfiguration:
+    InstanceType: m5.large
+    IamInstanceProfile: elasticsearch
+    SecurityGroups: sg-0b36d67d,sg-8d09e9fb
+    BlockDeviceMappings: "/dev/sdf=:300"
+  aws:ec2:vpc:
+    VPCId: vpc-a74b94dc
+    Subnets: subnet-5154076e,subnet-ce2dcb84
+    ELBSubnets: subnet-5154076e,subnet-ce2dcb84
+    ELBScheme: internal
+    AssociatePublicIpAddress: true
+  aws:elasticbeanstalk:environment:
+    ServiceRole: aws-elasticbeanstalk-elasticsearch-service-role
+
+files:
+  "/root/mount_nvme.sh":
+    mode: "744"
+    owner: root
+    group: root
+    content: |
+      #!/bin/bash
+      if lsblk | grep nvme1 &> /dev/null; then
+        if ! mount | grep nvme1 &> /dev/null; then
+          mkdir -p /var/esdata
+          mkfs -t ext4 /dev/nvme1n1
+          echo -e "/dev/nvme1n1\t/var/esdata\text4\tdefaults,noatime\t0\t2" >> /etc/fstab
+          mount /var/esdata
+          echo "NVMe disk mount setup and working"
+        else
+          echo "NVMe disk already mounted"
+        fi
+      else
+        echo "No NVMe disk connected"
+      fi

--- a/.ebextensions/00_cloud.config
+++ b/.ebextensions/00_cloud.config
@@ -1,4 +1,7 @@
 option_settings:
+  aws:autoscaling:asg:
+    MinSize: 1
+    MaxSize: 1
   aws:autoscaling:launchconfiguration:
     InstanceType: m5.large
     IamInstanceProfile: elasticsearch

--- a/.ebextensions/00_setup_volume.config
+++ b/.ebextensions/00_setup_volume.config
@@ -1,3 +1,0 @@
-option_settings:
-  aws:autoscaling:launchconfiguration:
-    BlockDeviceMappings: "/dev/sdf=:300"

--- a/.ebextensions/10_nginx.config
+++ b/.ebextensions/10_nginx.config
@@ -1,0 +1,47 @@
+files:
+  "/etc/nginx/nginx.conf":
+    mode: "744"
+    owner: root
+    group: root
+    content: |
+      user                    nginx;
+      error_log               /var/log/nginx/error.log warn;
+      pid                     /var/run/nginx.pid;
+      worker_processes        auto;
+      worker_rlimit_nofile    200000;
+      
+      events {
+          worker_connections  1024;
+      }
+      
+      http {
+          include       /etc/nginx/mime.types;
+          default_type  application/octet-stream;
+      
+          log_format  main  '$remote_addr - $remote_user [$time_local] "$request" '
+                            '$status $body_bytes_sent "$http_referer" '
+                            '"$http_user_agent" "$http_x_forwarded_for"';
+      
+          include       conf.d/*.conf;
+      
+          map $http_upgrade $connection_upgrade {
+              default     "upgrade";
+          }
+      
+          server {
+              listen        80 default_server;
+              access_log    /var/log/nginx/access.log main;
+      
+              client_header_timeout 60;
+              client_body_timeout   60;
+              keepalive_timeout     60;
+              gzip                  off;
+              gzip_comp_level       4;
+              gzip_types text/plain text/css application/json application/javascript application/x-javascript text/xml application/xml application/xml+rss text/javascript;
+              proxy_buffers 8 16k;
+              proxy_buffer_size 16k;
+
+              # Include the Elastic Beanstalk generated locations
+              include conf.d/elasticbeanstalk/*.conf;
+          }
+      }

--- a/.ebextensions/40_jvm.config
+++ b/.ebextensions/40_jvm.config
@@ -1,0 +1,40 @@
+files:
+  "/usr/lib/jvm/jre-1.8.0-openjdk.x86_64/lib/security/java.policy":
+    mode: "644"
+    owner: root
+    group: root
+    content: |
+      grant codeBase "file:${{java.ext.dirs}}/*" {
+              permission java.security.AllPermission;
+      };
+
+      grant {
+              permission java.lang.RuntimePermission "stopThread";
+              permission java.lang.RuntimePermission "accessDeclaredMembers";
+              permission java.lang.RuntimePermission "getClassLoader";
+              permission java.lang.RuntimePermission "accessClassInPackage.sun.misc";
+              permission java.lang.RuntimePermission "accessDeclaredMembers";
+              permission java.lang.reflect.ReflectPermission "suppressAccessChecks";
+              permission javax.management.MBeanTrustPermission "register";
+              permission javax.management.MBeanTrustPermission "findMBeanServer";
+              permission java.net.SocketPermission "localhost:0", "listen";
+              permission java.util.PropertyPermission "java.version", "read";
+              permission java.util.PropertyPermission "java.vendor", "read";
+              permission java.util.PropertyPermission "java.vendor.url", "read";
+              permission java.util.PropertyPermission "java.class.version", "read";
+              permission java.util.PropertyPermission "os.name", "read";
+              permission java.util.PropertyPermission "os.version", "read";
+              permission java.util.PropertyPermission "os.arch", "read";
+              permission java.util.PropertyPermission "file.separator", "read";
+              permission java.util.PropertyPermission "path.separator", "read";
+              permission java.util.PropertyPermission "line.separator", "read";
+              permission java.util.PropertyPermission "java.specification.version", "read";
+              permission java.util.PropertyPermission "java.specification.vendor", "read";
+              permission java.util.PropertyPermission "java.specification.name", "read";
+              permission java.util.PropertyPermission "java.vm.specification.version", "read";
+              permission java.util.PropertyPermission "java.vm.specification.vendor", "read";
+              permission java.util.PropertyPermission "java.vm.specification.name", "read";
+              permission java.util.PropertyPermission "java.vm.version", "read";
+              permission java.util.PropertyPermission "java.vm.vendor", "read";
+              permission java.util.PropertyPermission "java.vm.name", "read";
+      };

--- a/.ebextensions/50_elasticsearch.config
+++ b/.ebextensions/50_elasticsearch.config
@@ -8,53 +8,6 @@ option_settings:
     ES_JAVA_OPTS: -Xms6g -Xmx6g
 
 files:
-  "/etc/nginx/nginx.conf":
-    mode: "744"
-    owner: root
-    group: root
-    content: |
-      user                    nginx;
-      error_log               /var/log/nginx/error.log warn;
-      pid                     /var/run/nginx.pid;
-      worker_processes        auto;
-      worker_rlimit_nofile    200000;
-      
-      events {
-          worker_connections  1024;
-      }
-      
-      http {
-          include       /etc/nginx/mime.types;
-          default_type  application/octet-stream;
-      
-          log_format  main  '$remote_addr - $remote_user [$time_local] "$request" '
-                            '$status $body_bytes_sent "$http_referer" '
-                            '"$http_user_agent" "$http_x_forwarded_for"';
-      
-          include       conf.d/*.conf;
-      
-          map $http_upgrade $connection_upgrade {
-              default     "upgrade";
-          }
-      
-          server {
-              listen        80 default_server;
-              access_log    /var/log/nginx/access.log main;
-      
-              client_header_timeout 60;
-              client_body_timeout   60;
-              keepalive_timeout     60;
-              gzip                  off;
-              gzip_comp_level       4;
-              gzip_types text/plain text/css application/json application/javascript application/x-javascript text/xml application/xml application/xml+rss text/javascript;
-              proxy_buffers 8 16k;
-              proxy_buffer_size 16k;
-      
-              # Include the Elastic Beanstalk generated locations
-              include conf.d/elasticbeanstalk/*.conf;
-          }
-      }
-
   "/usr/lib/jvm/jre-1.8.0-openjdk.x86_64/lib/security/java.policy":
     mode: "644"
     owner: root

--- a/.ebextensions/50_elasticsearch.config
+++ b/.ebextensions/50_elasticsearch.config
@@ -149,18 +149,6 @@ files:
         echo "Script is not updated since last install, not running again."
       fi
 
-  "/opt/elasticbeanstalk/hooks/appdeploy/pre/01_setup_telegraf.sh":
-    mode: "744"
-    owner: root
-    group: root
-    content: |
-      #!/bin/bash
-      mkdir -p /tmp/setup_telegraf
-      cd /tmp/setup_telegraf
-      wget https://s3.amazonaws.com/devex-setup-info/dist/tools/setup_telegraf.sh
-      chmod +x setup_telegraf.sh
-      ./setup_telegraf.sh
-
 container_commands:
         01_run_setup_script:
             command: "/opt/elasticbeanstalk/hooks/appdeploy/pre/00_setup_elasticsearch.sh"

--- a/.ebextensions/50_elasticsearch.config
+++ b/.ebextensions/50_elasticsearch.config
@@ -8,26 +8,6 @@ option_settings:
     ES_JAVA_OPTS: -Xms6g -Xmx6g
 
 files:
-  "/root/mount_nvme.sh":
-    mode: "744"
-    owner: root
-    group: root
-    content: |
-      #!/bin/bash
-      if lsblk | grep nvme1 &> /dev/null; then
-        if ! mount | grep nvme1 &> /dev/null; then
-          mkdir -p /var/esdata
-          mkfs -t ext4 /dev/nvme1n1
-          echo -e "/dev/nvme1n1\t/var/esdata\text4\tdefaults,noatime\t0\t2" >> /etc/fstab
-          mount /var/esdata
-          echo "NVMe disk mount setup and working"
-        else
-          echo "NVMe disk already mounted"
-        fi
-      else
-        echo "No NVMe disk connected"
-      fi
-
   "/etc/nginx/nginx.conf":
     mode: "744"
     owner: root

--- a/.ebextensions/50_elasticsearch.config
+++ b/.ebextensions/50_elasticsearch.config
@@ -1,5 +1,10 @@
 option_settings:
   aws:elasticbeanstalk:application:environment:
+    CLUSTER_NAME: devex-es-test-logs-5-x
+    AWS_REGION: us-east-1
+    EC2_TAG_NAME: devex-es-test-logs-5-x
+    MASTER_NODES: 1
+    PORT: 9200
     ES_JAVA_OPTS: -Xms6g -Xmx6g
 
 files:

--- a/.ebextensions/50_elasticsearch.config
+++ b/.ebextensions/50_elasticsearch.config
@@ -8,46 +8,6 @@ option_settings:
     ES_JAVA_OPTS: -Xms6g -Xmx6g
 
 files:
-  "/usr/lib/jvm/jre-1.8.0-openjdk.x86_64/lib/security/java.policy":
-    mode: "644"
-    owner: root
-    group: root
-    content: |
-      grant codeBase "file:${{java.ext.dirs}}/*" {
-              permission java.security.AllPermission;
-      };
-
-      grant {
-              permission java.lang.RuntimePermission "stopThread";
-              permission java.lang.RuntimePermission "accessDeclaredMembers";
-              permission java.lang.RuntimePermission "getClassLoader";
-              permission java.lang.RuntimePermission "accessClassInPackage.sun.misc";
-              permission java.lang.RuntimePermission "accessDeclaredMembers";
-              permission java.lang.reflect.ReflectPermission "suppressAccessChecks";
-              permission javax.management.MBeanTrustPermission "register";
-              permission javax.management.MBeanTrustPermission "findMBeanServer";
-              permission java.net.SocketPermission "localhost:0", "listen";
-              permission java.util.PropertyPermission "java.version", "read";
-              permission java.util.PropertyPermission "java.vendor", "read";
-              permission java.util.PropertyPermission "java.vendor.url", "read";
-              permission java.util.PropertyPermission "java.class.version", "read";
-              permission java.util.PropertyPermission "os.name", "read";
-              permission java.util.PropertyPermission "os.version", "read";
-              permission java.util.PropertyPermission "os.arch", "read";
-              permission java.util.PropertyPermission "file.separator", "read";
-              permission java.util.PropertyPermission "path.separator", "read";
-              permission java.util.PropertyPermission "line.separator", "read";
-              permission java.util.PropertyPermission "java.specification.version", "read";
-              permission java.util.PropertyPermission "java.specification.vendor", "read";
-              permission java.util.PropertyPermission "java.specification.name", "read";
-              permission java.util.PropertyPermission "java.vm.specification.version", "read";
-              permission java.util.PropertyPermission "java.vm.specification.vendor", "read";
-              permission java.util.PropertyPermission "java.vm.specification.name", "read";
-              permission java.util.PropertyPermission "java.vm.version", "read";
-              permission java.util.PropertyPermission "java.vm.vendor", "read";
-              permission java.util.PropertyPermission "java.vm.name", "read";
-      };
-
   "/opt/elasticbeanstalk/hooks/appdeploy/pre/00_setup_elasticsearch.sh":
     mode: "744"
     owner: root

--- a/.ebextensions/60_telegraf.config
+++ b/.ebextensions/60_telegraf.config
@@ -1,0 +1,12 @@
+files:
+  "/opt/elasticbeanstalk/hooks/appdeploy/pre/01_setup_telegraf.sh":
+    mode: "744"
+    owner: root
+    group: root
+    content: |
+      #!/bin/bash
+      mkdir -p /tmp/setup_telegraf
+      cd /tmp/setup_telegraf
+      wget https://s3.amazonaws.com/devex-setup-info/dist/tools/setup_telegraf.sh
+      chmod +x setup_telegraf.sh
+      ./setup_telegraf.sh

--- a/README.md
+++ b/README.md
@@ -69,6 +69,7 @@ In the `.ebextension/00_cloud.config`, a whole set of cloud provisioning definit
  - `ELBScheme`: Must be `internal`, making the cluster not to be accessible from outside the VPC.
  - `AssociatePublicIpAddress`: Must be `true` so the instances are able to reach EB control plane.
  - `ServiceRole`: Service role, which must exist. See Prerequisites.
+ - `MinSize` and `MaxSize`: Define minimum and maximum number of nodes in cluster. Keep the same for stability.
 
 This file also provides with the script to mount the NVMe volume. Notice that this will only work on instance types that will see the volumes as NVMe. Also, if the instance belongs to m5d, r5d or c5d, this volume might not be needed.
 
@@ -86,7 +87,7 @@ You need to execute following commands:
 ```bash
 CLUSTER_NAME=company-es-environment-myfeature
 
-eb create -c ${CLUSTER_NAME} --platform=java-8 --scale 1 ${CLUSTER_NAME} --tags environment=$(echo ${CLUSTER_NAME} | awk -F- '{print $3}')
+eb create -c ${CLUSTER_NAME} --platform=java-8 ${CLUSTER_NAME} --tags environment=$(echo ${CLUSTER_NAME} | awk -F- '{print $3}')
 ```
 
 Where `CLUSTER_NAME` will be the CNAME and the Elastic Beanstalk environment name; these two must contain only letters, digits, and the dash character; `--scale 1` is how many nodes to create.

--- a/README.md
+++ b/README.md
@@ -72,6 +72,8 @@ In the `.ebextension/00_cloud.config`, a whole set of cloud provisioning definit
 
 This file also provides with the script to mount the NVMe volume. Notice that this will only work on instance types that will see the volumes as NVMe. Also, if the instance belongs to m5d, r5d or c5d, this volume might not be needed.
 
+The file `.ebextensions/60_telegraf.config` defines telegraf setup.
+
 ### Create new cluster
 
 Remember to export your AWS credentials before continuing.

--- a/README.md
+++ b/README.md
@@ -72,6 +72,8 @@ In the `.ebextension/00_cloud.config`, a whole set of cloud provisioning definit
 
 This file also provides with the script to mount the NVMe volume. Notice that this will only work on instance types that will see the volumes as NVMe. Also, if the instance belongs to m5d, r5d or c5d, this volume might not be needed.
 
+The file `.ebextensions/10_nginx.config` modifies Nginx configuration.
+
 The file `.ebextensions/60_telegraf.config` defines telegraf setup.
 
 ### Create new cluster

--- a/README.md
+++ b/README.md
@@ -47,16 +47,7 @@ Finally, create a new instance profile called `elasticsearch`, and associate the
 
 ### Configuration for a new cluster
 
-Few environment variables, in `.ebextensions/50_elasticsearch.config`, have to be specified before deployment:
-
- - `CLUSTER_NAME`: This is a name of your new shiny ElasticSearch cluster, please enforce something like `company-es-test-my-feature`. Must only contain letters, digits, and the dash caracter.
- - `AWS_REGION`: Region in which ES cluster will be created
- - `EC2_TAG_NAME`: This value should be equal to the AWS Name tag (same as environment name)
- - `MASTER_NODES`: Amount of master nodes, should be 1 for most test cases. The rule is simple, this number should equal to total number of nodes (N) divided by 2 plus 1. `N / 2 + 1`.
- - `PORT`: Should always be set to 9200, unless you changed ES http port.
- - `ES_JAVA_OPTS`: Set to 6g by default, allows to determine JVM heap size initial and maximum values, which, according to ES 5.6 documentation, must be the same size.
-
-This file also describes the process to setup Elasticsearch.
+#### Instance provisioning and scalability
  
 In the `.ebextension/00_cloud.config`, a whole set of cloud provisioning definitions are included:
  - `InstanceType`: Instance type to use for the nodes.
@@ -73,9 +64,28 @@ In the `.ebextension/00_cloud.config`, a whole set of cloud provisioning definit
 
 This file also provides with the script to mount the NVMe volume. Notice that this will only work on instance types that will see the volumes as NVMe. Also, if the instance belongs to m5d, r5d or c5d, this volume might not be needed.
 
+#### Nginx configuration
+
 The file `.ebextensions/10_nginx.config` modifies Nginx configuration.
 
+#### JVM policies
+
 The file `.ebextensions/40_jvm.config` sets JVM policies.
+
+#### Elasticsearch setup and configuration
+
+Few environment variables, in `.ebextensions/50_elasticsearch.config`, have to be specified before deployment:
+
+ - `CLUSTER_NAME`: This is a name of your new shiny ElasticSearch cluster, please enforce something like `company-es-test-my-feature`. Must only contain letters, digits, and the dash caracter.
+ - `AWS_REGION`: Region in which ES cluster will be created
+ - `EC2_TAG_NAME`: This value should be equal to the AWS Name tag (same as environment name)
+ - `MASTER_NODES`: Amount of master nodes, should be 1 for most test cases. The rule is simple, this number should equal to total number of nodes (N) divided by 2 plus 1. `N / 2 + 1`.
+ - `PORT`: Should always be set to 9200, unless you changed ES http port.
+ - `ES_JAVA_OPTS`: Set to 6g by default, allows to determine JVM heap size initial and maximum values, which, according to ES 5.6 documentation, must be the same size.
+
+This file also describes the process to setup Elasticsearch.
+
+#### Telegraf setup
 
 The file `.ebextensions/60_telegraf.config` defines telegraf setup.
 

--- a/README.md
+++ b/README.md
@@ -74,6 +74,8 @@ This file also provides with the script to mount the NVMe volume. Notice that th
 
 The file `.ebextensions/10_nginx.config` modifies Nginx configuration.
 
+The file `.ebextensions/40_jvm.config` sets JVM policies.
+
 The file `.ebextensions/60_telegraf.config` defines telegraf setup.
 
 ### Create new cluster

--- a/README.md
+++ b/README.md
@@ -16,7 +16,6 @@ If you plan to deploy the new cluster in a VPC, you will need also the following
  - VPC ID
  - VPC Subnets, might be different for EC2 instances and ELB
  - VPC Security Groups
- - You will need to have capcom from [Poka-yoke's spaceflight](https://github.com/poka-yoke/spaceflight) installed.
 
 ## Deployment
 
@@ -48,27 +47,18 @@ Finally, create a new instance profile called `elasticsearch`, and associate the
 
 ### Configuration for a new cluster
 
-Few environment variables, in `.env.example`, have to be specified before deployment:
+Few environment variables, in `.ebextensions/50_elasticsearch.config`, have to be specified before deployment:
 
  - `CLUSTER_NAME`: This is a name of your new shiny ElasticSearch cluster, please enforce something like `company-es-test-my-feature`. Must only contain letters, digits, and the dash caracter.
  - `AWS_REGION`: Region in which ES cluster will be created
  - `EC2_TAG_NAME`: This value should be equal to the AWS Name tag (same as environment name)
  - `MASTER_NODES`: Amount of master nodes, should be 1 for most test cases. The rule is simple, this number should equal to total number of nodes (N) divided by 2 plus 1. `N / 2 + 1`.
  - `PORT`: Should always be set to 9200, unless you changed ES http port.
+ - `ES_JAVA_OPTS`: Set to 6g by default, allows to determine JVM heap size initial and maximum values, which, according to ES 5.6 documentation, must be the same size.
  
-In the `.ebextensions/50_setup_elasticsearch.config`, under the options section, the environment variable `ES_JAVA_OPTS` is defined.
-Since version 5.6, it's a requirement to have the maximum and initial heap memory settings to be the same. It's hardcoded to be 6 gigabytes (6g), but feel free to change according to your needs.
-
 In the `.ebextension/00_setup_volume.config`, a new 300 Gb EBS volume is specified to be provisioned for every instance, so it becomes storage for ES data files, but only if the instance sees it as `/dev/nvme1`.
 
 If the instance type used has local NVMe SSD disk, i.e. m5d, r5d, c5d families, it will be used as the storage for `/var/esdata`, so the file `.ebextensions/00_setup_volume.config` should be removed to avoid provisioning extra unused disks.
-
-### Usage of `.env` file
-
-See example in `.env.example` file.
-You can create a copy of this file, like `.env.my-feature, and set the previously explained variables there.
-
-**Notice this file will not be committed anywhere**
 
 ### Create new cluster
 
@@ -76,17 +66,16 @@ Remember to export your AWS credentials before continuing.
 You need to execute following commands:
 
 ```bash
-ENV_VARS=$(cat .env.my-feature | tr "\n" "," | sed -e 's/,$//')
-export $(head -1 .env.my-feature)
-VPC_NAME=test
+CLUSTER_NAME=company-es-environment-myfeature
+VPC_NAME=Test
 VPC_ID=$(aws ec2 describe-vpcs --output text --filters Name=tag:Name,Values=${VPC_NAME} | grep VPCS | awk '{print $NF}')
 VPC_EC2_SUBNETS=$(aws ec2 describe-subnets --output text --filters Name=vpc-id,Values=${VPC_ID} | grep SUBNETS | awk '{printf (NR>1?",":"") $(NF-1)}')
 VPC_SECURITYGROUPS=$(capcom list | grep $(echo $VPC_NAME|tr '[:upper:]' '[:lower:]') | egrep "management|elasticsearch" | grep -v elb | awk '{print $2}' | paste -sd "," -)
 
-eb create -c ${CLUSTER_NAME} --envvars ${ENV_VARS} --platform=java-8 -i m4.xlarge --scale 3 ${CLUSTER_NAME} --instance_profile elasticsearch --service-role aws-elasticbeanstalk-elasticsearch-service-role --vpc.id ${VPC_ID} --vpc.ec2subnets ${VPC_EC2_SUBNETS} --vpc.elbsubnets ${VPC_EC2_SUBNETS} --vpc.securitygroups ${VPC_SECURITYGROUPS} --vpc.publicip --tags environment=$(echo ${CLUSTER_NAME} | awk -F- '{print $3}')
+eb create -c ${CLUSTER_NAME} --platform=java-8 -i m5.large --scale 1 ${CLUSTER_NAME} --instance_profile elasticsearch --service-role aws-elasticbeanstalk-elasticsearch-service-role --vpc.id ${VPC_ID} --vpc.ec2subnets ${VPC_EC2_SUBNETS} --vpc.elbsubnets ${VPC_EC2_SUBNETS} --vpc.securitygroups ${VPC_SECURITYGROUPS} --vpc.publicip --tags environment=$(echo ${CLUSTER_NAME} | awk -F- '{print $3}')
 ```
 
-Where `company-es-test-my-feature` after `-c` is a CNAME; `company-es-test-my-feature` is the Elastic Beanstalk environment name; these two must contain only letters, digits, and the dash character; `m4.xlarge` is a instance type and `--scale 1` is how many nodes to create.
+Where `CLUSTER_NAME` will be the CNAME and the Elastic Beanstalk environment name; these two must contain only letters, digits, and the dash character; `m5.large` is a instance type and `--scale 1` is how many nodes to create.
 
 ### Configure AWS Security Groups
 

--- a/README.md
+++ b/README.md
@@ -55,10 +55,22 @@ Few environment variables, in `.ebextensions/50_elasticsearch.config`, have to b
  - `MASTER_NODES`: Amount of master nodes, should be 1 for most test cases. The rule is simple, this number should equal to total number of nodes (N) divided by 2 plus 1. `N / 2 + 1`.
  - `PORT`: Should always be set to 9200, unless you changed ES http port.
  - `ES_JAVA_OPTS`: Set to 6g by default, allows to determine JVM heap size initial and maximum values, which, according to ES 5.6 documentation, must be the same size.
- 
-In the `.ebextension/00_setup_volume.config`, a new 300 Gb EBS volume is specified to be provisioned for every instance, so it becomes storage for ES data files, but only if the instance sees it as `/dev/nvme1`.
 
-If the instance type used has local NVMe SSD disk, i.e. m5d, r5d, c5d families, it will be used as the storage for `/var/esdata`, so the file `.ebextensions/00_setup_volume.config` should be removed to avoid provisioning extra unused disks.
+This file also describes the process to setup Elasticsearch.
+ 
+In the `.ebextension/00_cloud.config`, a whole set of cloud provisioning definitions are included:
+ - `InstanceType`: Instance type to use for the nodes.
+ - `IamInstanceProfile`: IAM instance profile, which must exist. See Prerequisites.
+ - `SecurityGroups`: Comma separated list of Security groups identifiers.
+ - `BlockDeviceMappings`: Extra block devices needed. Example: "/dev/sdf=:300", will add a new 300Gb EBS volume. Review [documentation](https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/block-device-mapping-concepts.html) for other options.
+ - `VPCId`: VPC identifier.
+ - `Subnets`: Comma separated list of subnets for nodes allocation.
+ - `ELBSubnets`: Comma separated list of subnets for ELB nodes allocation.
+ - `ELBScheme`: Must be `internal`, making the cluster not to be accessible from outside the VPC.
+ - `AssociatePublicIpAddress`: Must be `true` so the instances are able to reach EB control plane.
+ - `ServiceRole`: Service role, which must exist. See Prerequisites.
+
+This file also provides with the script to mount the NVMe volume. Notice that this will only work on instance types that will see the volumes as NVMe. Also, if the instance belongs to m5d, r5d or c5d, this volume might not be needed.
 
 ### Create new cluster
 
@@ -67,15 +79,11 @@ You need to execute following commands:
 
 ```bash
 CLUSTER_NAME=company-es-environment-myfeature
-VPC_NAME=Test
-VPC_ID=$(aws ec2 describe-vpcs --output text --filters Name=tag:Name,Values=${VPC_NAME} | grep VPCS | awk '{print $NF}')
-VPC_EC2_SUBNETS=$(aws ec2 describe-subnets --output text --filters Name=vpc-id,Values=${VPC_ID} | grep SUBNETS | awk '{printf (NR>1?",":"") $(NF-1)}')
-VPC_SECURITYGROUPS=$(capcom list | grep $(echo $VPC_NAME|tr '[:upper:]' '[:lower:]') | egrep "management|elasticsearch" | grep -v elb | awk '{print $2}' | paste -sd "," -)
 
-eb create -c ${CLUSTER_NAME} --platform=java-8 -i m5.large --scale 1 ${CLUSTER_NAME} --instance_profile elasticsearch --service-role aws-elasticbeanstalk-elasticsearch-service-role --vpc.id ${VPC_ID} --vpc.ec2subnets ${VPC_EC2_SUBNETS} --vpc.elbsubnets ${VPC_EC2_SUBNETS} --vpc.securitygroups ${VPC_SECURITYGROUPS} --vpc.publicip --tags environment=$(echo ${CLUSTER_NAME} | awk -F- '{print $3}')
+eb create -c ${CLUSTER_NAME} --platform=java-8 --scale 1 ${CLUSTER_NAME} --tags environment=$(echo ${CLUSTER_NAME} | awk -F- '{print $3}')
 ```
 
-Where `CLUSTER_NAME` will be the CNAME and the Elastic Beanstalk environment name; these two must contain only letters, digits, and the dash character; `m5.large` is a instance type and `--scale 1` is how many nodes to create.
+Where `CLUSTER_NAME` will be the CNAME and the Elastic Beanstalk environment name; these two must contain only letters, digits, and the dash character; `--scale 1` is how many nodes to create.
 
 ### Configure AWS Security Groups
 


### PR DESCRIPTION
These changes improve ES cluster setup in some ways:

- Move environment variables definition to EB extensions files, removing the need for the `.env` file.
- Put infrastructure provisioning definition and configuration in a separate file, removing many arguments.
- Move Telegraf, Nginx, and JVM setup to a separate files.
- Improve documentation.

Refs [DVX-8195](https://mydevex.atlassian.net/browse/DVX-8195)