### PR TITLE
DVX-8356 Fix master discovery for ES5.6

### DIFF
--- a/config/elasticsearch.yml
+++ b/config/elasticsearch.yml
@@ -14,6 +14,7 @@ discovery:
     read_timeout: 30s
     tag.Name: ${EC2_TAG_NAME}
     host_type: private_dns
+    endpoint: ec2.us-east-1.amazonaws.com
 
 discovery.zen:
   minimum_master_nodes: ${MASTER_NODES}
@@ -26,7 +27,7 @@ script.engine.groovy.inline.aggs: on
 script.engine.groovy.inline.search: on
 
 network:
-    host: 0.0.0.0
+    host: _ec2_
 
 http:
     host: 0.0.0.0


### PR DESCRIPTION
While deploying new ES5 production cluster the nodes were not forming
the cluster, due to the lack of a couple of configurations. The
`network` definition might be superfluous, but this is how it is now
working.

Refs [DVX-8356](https://mydevex.atlassian.net/browse/DVX-8356)