### PR TITLE
INF-16 Change source for telegraf setup script

### DIFF
--- a/.ebextensions/60_telegraf.config
+++ b/.ebextensions/60_telegraf.config
@@ -7,6 +7,6 @@ files:
       #!/bin/bash
       mkdir -p /tmp/setup_telegraf
       cd /tmp/setup_telegraf
-      wget https://s3.amazonaws.com/devex-setup-info/dist/tools/setup_telegraf.sh
+      wget https://s3.amazonaws.com/devex-dist/telegraf/setup_telegraf.sh
       chmod +x setup_telegraf.sh
       ./setup_telegraf.sh


### PR DESCRIPTION
As of [INF-16](https://mydevex.atlassian.net/browse/INF-16),
telegraf setup script will be hosted in the devex-dist bucket.