### PR TITLE
INF-441 Fix Prometheus exporter URL

### DIFF
--- a/.ebextensions/50_elasticsearch.config
+++ b/.ebextensions/50_elasticsearch.config
@@ -45,7 +45,7 @@ files:
 
         /usr/local/elasticsearch-$ES_VER/bin/elasticsearch-plugin install discovery-ec2
         /usr/local/elasticsearch-$ES_VER/bin/elasticsearch-plugin install repository-s3
-        /usr/local/elasticsearch-$ES_VER/bin/elasticsearch-plugin install -b https://distfiles.compuscene.net/elasticsearch/elasticsearch-prometheus-exporter-$ES_VER.0.zip
+        /usr/local/elasticsearch-$ES_VER/bin/elasticsearch-plugin install -b https://github.com/vvanholl/elasticsearch-prometheus-exporter/releases/download/5.6.11.0/elasticsearch-prometheus-exporter-5.6.11.0.zip
 
         test -f /opt/aws/bin/elasticsearch && unlink /opt/aws/bin/elasticsearch
         ln -s /usr/local/elasticsearch-$ES_VER/bin/elasticsearch /opt/aws/bin


### PR DESCRIPTION
The download URL for the Prometheus exporter was wrong. This replaces
it with the correct one.

Refs [INF-441](https://mydevex.atlassian.net/browse/INF-441)